### PR TITLE
`%wild` hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ UIPs can be divided into the following categories:
 | [0119](./UIPS/UIP-0119.md) | Pretty Printer Improvements | ~sidnym-ladrut               | Draft     | Standards |
 | [0120](./UIPS/UIP-0120.md) | HTTP Streaming            | ~rovnys-ricfer                 | Draft     | Standards |
 | [0121](./UIPS/UIP-0121.md) | %pine Request at Latest   | ~rovnys-ricfer                 | Draft     | Standards |
+| [0122](./UIPS/UIP-0122.md) | %wild: Stateless jet registration | ~ritpub-sipsyl         | Draft     | Standards |
 
 ## Background
 

--- a/UIPS/UIP-0122.md
+++ b/UIPS/UIP-0122.md
@@ -139,8 +139,8 @@ The type `$type` of Hoon types is extended with one case:
 It is introduced by the `~%` rune (to which `~/` reduces).
 When typing `~% p q r s` (where `h` contains the AST children)
 - Type `s`, call it `ts` and verify that it types to `%core`. Otherwise fail.
-- Type `q:s`, call it `tqs` and verify that it types to `%wilt`. Otherwise fail.
-- Produce the result type as follows: `[%wild [p.h p.tqs] q.h ts]`.
+- Mint `q:s`, call its `tqs` and verify that it types to `%wilt`. Otherwise fail. Call its nock `nqs` and verify that it is `[1 0]` or `[0 <axis>]`. Otherwise fail.
+- Produce the result type as follows: `[%wild [p.h p.tqs] +.nqs ts]`.
 
 This both records the labeled core hierarchy in the type, and simultaneously checks the consistency of `~%` core labeling *as part of Hoon typechecking*.
 

--- a/UIPS/UIP-0122.md
+++ b/UIPS/UIP-0122.md
@@ -11,19 +11,21 @@ created: 2024-03-25
 
 ## Abstract
 
-This proposal introduces a stateless approach to jet registration in Nock interpreters, utilizing a dynamic hint labeled `%wild`. The `%wild` hint contains the necessary slice of "cold state" for the hinted Nock, thereby avoiding issues with state maintenance and preservation. This approach offers a simple solution to the problems of state in jet registration.
+This proposal introduces a stateless approach to jet registration in Nock interpreters, utilizing a dynamic hint labeled `%wild`. The `%wild` hint directly contains the necessary slice of "cold state" (labels for nested core batteries) for the hinted Nock, thereby avoiding issues with state maintenance and preservation. This approach offers a simple solution to the problems of state in jet registration.
 
 The `%wild` hint can be composed by Hoon and can be implemented using existing information in the subject type, extended only by labels from existing `%fast`-hint runes. It also provides a scoping mechanism which prevents user code from altering kernel code registrations.
 
-An additional advantage of this  approach is its potential to fix the jet mismatch of `+mink`, without requiring any injection of state.
+An additional advantage of this approach is its potential to fix the jet mismatch of `+mink`, without requiring any injection of state. Presently, the jet for `+mink` will not return stack traces from jetted Nock, though the hoon implementation specifies returning all stack traces without regard to jets.
 
 ## Motivation
 
-Currently Vere and Ares both handle jet registrations provided by `%fast` hints. By convention and implementation, a `%fast` hint wraps the production of a core, and registers that core's *battery* (axis 2) along with a registered heirarchy of already-registered batteries which match a parent core, whose axis in the newly-registered core is given in the hint. The label provided in a `%fast` hint are consed onto those for parent cores, producing a `$path` for each core registered. This allows us to recognize cores as having a particular label. This ability is fundamental to practical jetting systems.
+Currently Vere and Ares both handle jet registrations provided by `%fast` hints. By convention and implementation, a `%fast` hint wraps the production of a core, and registers that core's *battery* (axis 2) along with a registered heirarchy of already-registered batteries which match a parent core, whose axis in the newly-registered core is given in the hint. The label provided in a `%fast` hint is consed onto those for parent cores, producing a `$path` for each core registered. This allows us to recognize cores as having a particular label. This ability is fundamental to practical jetting systems.
 
 To correctly implement core labeling with `%fast` hints, an interpreter must maintain *state*. The state directly assembled from `%fast` hints is conventionally referred to as the "cold" state (contrasted with the "hot" state which is shipped with the interpreter binary and maps labels to jets, or the "warm" state which is the join of these two states.)
 
 Cold state must be accumulated throughout the lifetime of the pier. Once the `%fast` hint wrapping the introduction of a core is evaluated, it is *gone* and cannot, in general, be recovered, therefore there is in general no safe way for the interpreter to recognize that registrations can be deleted. The technical term for such a design is a *memory leak*. (Thank you to ~fodwyt-ragful for this insight.)
+
+(For a more thorough treatment of the current core-labeling and jetting system see ["Fast Hints and Jets"](https://docs.urbit.org/language/nock/guides/jetting)).
 
 Further, it is not in general possible to assume the inter-pier portability of core-based state machines (Arvo, Ares codegen, Gall agents, etc). The only way in which this is possible at all is to provide the *introduction forms* (usually typed as `(trap vase)` in Hoon) which will run the fast hints in the target pier.
 
@@ -31,21 +33,23 @@ A simpler, stateless approach is to embrace the referential transparency of a de
 
 ## Specification
 
-Nock interpreters SHOULD respect a dynamic hint labeled `%wild`, whose clue molds to the following Hoon structure:
+Nock interpreters SHOULD respect a dynamic hint labeled `%wild`, whose clue molds to the `$wilt` structure as defined below.
 
 ```hoon
 |%
-+$  cape  $@(? [cape cape])
-+$  sock  [=cape data=*]
-+$  wilt  (list [l=* s=sock])
++$  cape  $@(? [cape cape])    ::  noun mask; & means known, | unknown
++$  sock  [=cape data=*]       ::  core with mask; only & values need to match  
++$  wilt  (list [l=* s=sock])  ::  list of labeled masked cores
 --
 ```
 
-The list SHOULD be interpreted as the entire set of jet registrations for the enclosed Nock. For each element in the list, the label `l` SHOULD be interpreted as a core label, and the template `s` SHOULD be interpreted as a noun template to be matched as follows:
+The list SHOULD be interpreted as the entire set of jet registrations for the enclosed Nock. A Nock interpreter will, at each callsite, check if there is a label for the core to be fired. Semantically, each `$sock` in the list of registrations is checked for a match against the subject (which in Hoon-emitted code is a core). If a matching sock is found, then the label and formula are checked against the interpreter's "hot state" (a mapping from labels and formulas to actual jets) and the jet is invoked in place of direct evaluation of the Nock.
 
-- If the `cape` is `&`/`0` then `data` is compared to the core and a match is returned if equal.
-- If the `cape` is `|`/`1` then the match is tautological.
-- If the `cape` is a cell, then the sock composed of the head of `cape` and the head of `data` is recursively matched to the head of the core, and mutatis mutandis for the tails.
+For each element in the list, the label `l` SHOULD be interpreted as a core label, and the template `s` SHOULD be interpreted as a noun template to be matched as follows:
+
+- If the `cape` is `&` then `data` is compared to the core and a match is returned if equal.
+- If the `cape` is `|` then any noun matches the sock.
+- If the `cape` is a cell, then matching is performed recursively
 - If the `cape` of a `sock` is a cell but `data` is an atom, then the registration MUST be discarded for an invalid sock.
 
 If a match is returned, the interpreter SHOULD treat the matched core as having the given label (`l`) for purposes of jetting and profiling.
@@ -62,9 +66,61 @@ A separate rune (`~.` is proposed) can extract core labels from the type of an a
 
 Thus, no relabeling of cores is necessary, the only Hoon level change is the addition of a simple rune wrapping a fixed number of entry points to Arvo. Hoon can compose the `%wild` hint's clue entirely from information tracked in the subject type.
 
+## Example
+
+Consider the following jetted standard library (`vial.hoon`)
+
+```hoon=
+=>  ~%  %vial.100  %vial
+~%  %one  +3..  ~
+|%
+~/  %dec
+++  dec
+  |=  a=@
+  ?<  =(a 0)
+  =|  b=@
+  |-  ^-  @
+  ?:  =(a +(b))  b
+  $(b +(b))
+--
+```
+
+The `%fast` hints on lines 1, 2, and 4 are compiled into Nock, but also result in labels in the Hoon type. For the `+dec` gate, the core is labeled `/dec/one/vial.100`.
+
+Now consider the following trivial lifecycle door (`life.hoon`):
+
+
+```hoon=
+/+  vial
+=>  vial
+|_  many=@
+++  this  .
+++  peek
+  |=  pax=*
+  ?>  =(pax /how/<many>)
+  many
+++  poke
+  |=  up=?
+  ~.  +7..
+  ^-  _this
+  ?:  up  this(many +(many))
+  this(many (dec many))
+--
+```
+  
+In this example, the `~.` rune would compile to a `%wild` hint with three elements:
+
+- `[l=/vial.100 s=[& %vial]]`
+- `[l=/one/vial.100 s=[[& &] [<one battery> %vial]]`
+- `[l=/dec/one/vial.100 s=[[& | & &] <dec battery> ~ <one battery> %vial]`
+
+For the entire scope of the `~.` rune, a conforming interpreter would use this as the set of registered cores in order to match jets or produce traces. The list is extracted labels from the *type* of the first subhoon: `+7..` and (recursively) the result types of any arms of any cores in the type.
+
+## Bonus: fix `+mink` jet mismatch
+
 A further advantage, pointed out by ~master-morzod, is that type-level availability of core labels could be used to fix the jet mismatch of `+mink` in an ergonomic way. If the sample of `+mink` is extended to contain jet registrations (in the same `$wilt` mold), its semantics can be fixed to never produce a stack trace underneath a labeled core. The jet for `+mink` can load the supplied `$wilt` as its local jet registrations, and the interpreter can likewise refuse to produce stack traces under labeled cores, even if they are in fact unjetted. Of course `+mink` should also explicitly handle the `%wild` hint.
 
-A vase-mode wrapper around `+mink` can then extract the necessary registrations from the type carried by the vase.
+A vase-mode wrapper around `+mink` can then extract the necessary registrations from the type carried by the vase, using the same algorithm as for compiling `~.`, but at runtime. The extraction would almost certainly need to be persistently memoized for reasonable performance.
 
 ## Backwards Compatibility
 
@@ -72,17 +128,22 @@ Interpreters are free to ignore `%wild` hints and use existing jet registration 
 
 ## Reference Implementation
 
-TBW
+A full reference implementation is not offered, as it would entail changes to the hoon compiler and both runtimes. However, the added case required in the type `$type` of Hoon types and an overview of its introduction and elimination follow.
 
-<!--
-  This section is optional.
+The type `$type` of Hoon types is extended with one case:
 
-  The Reference Implementation section should include a minimal implementation that assists in understanding or implementing this specification. It should not include project build files. The reference implementation is not a replacement for the Specification section, and the proposal should still be understandable without it.
+`[%wilt p=path q=@ r=type]`.
 
-  If the reference implementation is too large to reasonably be included inline, then external links to the urbit/urbit and/or urbit/vere repositories are allowed.
+It is introduced by the `~%` rune (to which `~/` reduces).
+When typing `~% p q r s` (where `h` contains the AST children)
+- Type `s`, call it `ts` and verify that it types to `%core`. Otherwise fail.
+- Type `q:s`, call it `tqs` and verify that it types to `%wilt`. Otherwise fail.
+- Produce the result type as follows: `[%wild [p.h p.tqs] q.h ts]`.
 
-  TODO: Remove this comment before submitting
--->
+This both records the labeled core hierarchy in the type, and simultaneously checks the consistency of `~%` core labeling *as part of Hoon typechecking*.
+
+TBW: extract core labels by traversing type, producing socks for cores, and recursively `mint`ing arms of cores.
+
 
 ## Security Considerations
 

--- a/UIPS/UIP-0122.md
+++ b/UIPS/UIP-0122.md
@@ -114,6 +114,8 @@ In this example, the `~.` rune would compile to a `%wild` hint with three elemen
 - `[l=/one/vial.100 s=[[& &] [<one battery> %vial]]`
 - `[l=/dec/one/vial.100 s=[[& | & &] <dec battery> ~ <one battery> %vial]`
 
+(In practice the `cape`s would be normalized by rewriting `[& &]` to `&`, however here we leave them denormalized for ease of following the example.)
+
 For the entire scope of the `~.` rune, a conforming interpreter would use this as the set of registered cores in order to match jets or produce traces. The list is extracted labels from the *type* of the first subhoon: `+7..` and (recursively) the result types of any arms of any cores in the type.
 
 ## Bonus: fix `+mink` jet mismatch

--- a/UIPS/UIP-0122.md
+++ b/UIPS/UIP-0122.md
@@ -1,5 +1,5 @@
 ---
-uip: 0122
+uip: "0122"
 title: "%wild: Stateless jet registration"
 description: Propose a new system for deriving jet registrations and hinting which requires no stored state in the interpreter.
 author: ~ritpub-sipsyl (eamsden) 

--- a/UIPS/UIP-0122.md
+++ b/UIPS/UIP-0122.md
@@ -1,5 +1,5 @@
 ---
-uip: 01XX
+uip: 0122
 title: "%wild: Stateless jet registration"
 description: Propose a new system for deriving jet registrations and hinting which requires no stored state in the interpreter.
 author: ~ritpub-sipsyl (eamsden) 

--- a/UIPS/UIP-01XX.md
+++ b/UIPS/UIP-01XX.md
@@ -11,13 +11,11 @@ created: 2024-03-25
 
 ## Abstract
 
-TBD
+This proposal introduces a stateless approach to jet registration in Nock interpreters, utilizing a dynamic hint labeled `%wild`. The `%wild` hint contains the necessary slice of "cold state" for the hinted Nock, thereby avoiding issues with state maintenance and preservation. This approach offers a simple solution to the problems of state in jet registration.
 
-<!--
-  The Abstract is a multi-sentence (short paragraph) technical summary. This should be a very terse and human-readable version of the specification section. Someone should be able to read only the abstract to get the gist of what this specification does.
+The `%wild` hint can be composed by Hoon and can be implemented using existing information in the subject type, extended only by labels from existing `%fast`-hint runes. It also provides a scoping mechanism which prevents user code from altering kernel code registrations.
 
-  TODO: Remove this comment before submitting
--->
+An additional advantage of this  approach is its potential to fix the jet mismatch of `+mink`, without requiring any injection of state.
 
 ## Motivation
 
@@ -64,11 +62,13 @@ A separate rune (`~.` is proposed) can extract core labels from the type of an a
 
 Thus, no relabeling of cores is necessary, the only Hoon level change is the addition of a simple rune wrapping a fixed number of entry points to Arvo. Hoon can compose the `%wild` hint's clue entirely from information tracked in the subject type.
 
-A further advantage, pointed out by ~master-morzod, is that such a hint could be used to fix the jet mismatch of `+mink`. The rule is simple: neither `+mink` as written, nor the interpreter which is jetting it, ever produce stack traces when executing an arm of a labeled core. This information is accessible to `+mink` without requiring any injection of state.
+A further advantage, pointed out by ~master-morzod, is that type-level availability of core labels could be used to fix the jet mismatch of `+mink` in an ergonomic way. If the sample of `+mink` is extended to contain jet registrations (in the same `$wilt` mold), its semantics can be fixed to never produce a stack trace underneath a labeled core. The jet for `+mink` can load the supplied `$wilt` as its local jet registrations, and the interpreter can likewise refuse to produce stack traces under labeled cores, even if they are in fact unjetted. Of course `+mink` should also explicitly handle the `%wild` hint.
+
+A vase-mode wrapper around `+mink` can then extract the necessary registrations from the type carried by the vase.
 
 ## Backwards Compatibility
 
-Interpreters are free to ignore `%wild` hints and use existing jet registration implementations, such as cold state derived from `%fast` hints.
+Interpreters are free to ignore `%wild` hints and use existing jet registration implementations, such as cold state derived from `%fast` hints. However, this will preserve the extant jet mismatch with `+mink`.
 
 ## Reference Implementation
 

--- a/UIPS/UIP-01XX.md
+++ b/UIPS/UIP-01XX.md
@@ -4,8 +4,8 @@ title: "%wild: Stateless jet registration"
 description: Propose a new system for deriving jet registrations and hinting which requires no stored state in the interpreter.
 author: ~ritpub-sipsyl (eamsden) 
 status: Draft
-type: <Standards Track, Process, or Informational>
-category: Kernel, Hoon, Nock # Only required for Standards Track. Otherwise, remove this field.
+type: Standards Track
+category: Hoon, Nock # Only required for Standards Track. Otherwise, remove this field.
 created: 2024-03-25
 ---
 


### PR DESCRIPTION
## Abstract

This proposal introduces a stateless approach to jet registration in Nock interpreters, utilizing a dynamic hint labeled `%wild`. The `%wild` hint directly contains the necessary slice of "cold state" (labels for nested core batteries) for the hinted Nock, thereby avoiding issues with state maintenance and preservation. This approach offers a simple solution to the problems of state in jet registration.

The `%wild` hint can be composed by Hoon and can be implemented using existing information in the subject type, extended only by labels from existing `%fast`-hint runes. It also provides a scoping mechanism which prevents user code from altering kernel code registrations.

An additional advantage of this approach is its potential to fix the jet mismatch of `+mink`, without requiring any injection of state. Presently, the jet for `+mink` will not return stack traces from jetted Nock, though the hoon implementation specifies returning all stack traces without regard to jets.