### PR TITLE
meta: quote UIP numbers in metadata so they're not interpreted as octal by GH markdown renderer

### DIFF
--- a/UIPS/UIP-0001.md
+++ b/UIPS/UIP-0001.md
@@ -1,5 +1,5 @@
 ---
-uip: 0001
+uip: "0001"
 title: UIP Purpose and Guidelines
 status: Living
 type: Process

--- a/UIPS/UIP-0100.md
+++ b/UIPS/UIP-0100.md
@@ -1,5 +1,5 @@
 ---
-uip: 0100
+uip: "0100"
 title: Sticky Scry
 description: Extend Remote Scry to Support Subscriptions
 author: ~rovnys-ricfer

--- a/UIPS/UIP-0101.md
+++ b/UIPS/UIP-0101.md
@@ -1,5 +1,5 @@
 ---
-uip: 0101
+uip: "0101"
 title: "%lick"
 description: An IPC vane
 author: ~mopfel-winrux (@mopfel-winrux)

--- a/UIPS/UIP-0102.md
+++ b/UIPS/UIP-0102.md
@@ -1,5 +1,5 @@
 ---
-uip: 0102
+uip: "0102"
 title: Symmetric Routing
 description: Next-Generation Network Routing and Peer Discovery
 author: ~rovnys-ricfer

--- a/UIPS/UIP-0103.md
+++ b/UIPS/UIP-0103.md
@@ -1,5 +1,5 @@
 ---
-uip: 0103
+uip: "0103"
 title: Persistent Nock Caching
 description: Persistent Runtime Caches for Nock Computations
 author: ~rovnys-ricfer & ~mastyr-bottec

--- a/UIPS/UIP-0104.md
+++ b/UIPS/UIP-0104.md
@@ -1,5 +1,5 @@
 ---
-uip: 0104
+uip: "0104"
 title: Scry Store
 description: External Storage for Scry Bindings
 author: ~rovnys-ricfer

--- a/UIPS/UIP-0105.md
+++ b/UIPS/UIP-0105.md
@@ -1,5 +1,5 @@
 ---
-uip: 0105
+uip: "0105"
 title: Drop Pokes to Dead Agents
 description: Fix a DoS Vector in Gall
 author: ~rovnys-ricfer

--- a/UIPS/UIP-0106.md
+++ b/UIPS/UIP-0106.md
@@ -1,5 +1,5 @@
 ---
-uip: 0106
+uip: "0106"
 title: Scry over HTTP
 description: Map URLs to Scry Requests
 author: ~watter-parter, ~rovnys-ricfer, ~master-morzod, ~palfun-foslup

--- a/UIPS/UIP-0107.md
+++ b/UIPS/UIP-0107.md
@@ -1,5 +1,5 @@
 ---
-uip: 0107
+uip: "0107"
 title: Auras Renovation
 description: Address inconsistencies in the aura type system
 author: ~ponmep-litsem

--- a/UIPS/UIP-0108.md
+++ b/UIPS/UIP-0108.md
@@ -1,5 +1,5 @@
 ---
-uip: 0108
+uip: "0108"
 title: "`%yard`:  A Developer Commons"
 description: A standard desk distributing developer tools not justified in `%base`.
 author: ~lagrev-nocfep

--- a/UIPS/UIP-0109.md
+++ b/UIPS/UIP-0109.md
@@ -1,5 +1,5 @@
 ---
-uip: 0109
+uip: "0109"
 title: Essential Desks
 description: Introduce a distinction between essential and non-essential desks, which block and do not block OTAs, respectively.
 author: Philip Monk (philipcmonk)

--- a/UIPS/UIP-0110.md
+++ b/UIPS/UIP-0110.md
@@ -1,5 +1,5 @@
 ---
-uip: 0110
+uip: "0110"
 title: Gall Agent Backups
 description: Expose agent state to enable backup and restore.
 author: ~midden-fabler (@midden-fabler), ~mopfel-winrux (@mopfel-winrux)

--- a/UIPS/UIP-0111.md
+++ b/UIPS/UIP-0111.md
@@ -1,5 +1,5 @@
 ---
-uip: 0111
+uip: "0111"
 title: Desk Publisher Switcher
 description: Allow desk publishers to tell subscribers to switch to a new source for updates.
 author: ~tinnus-napbus

--- a/UIPS/UIP-0112.md
+++ b/UIPS/UIP-0112.md
@@ -1,5 +1,5 @@
 ---
-uip: 0112
+uip: "0112"
 title: Informal Ping
 description: informal (stateless) pinging to reduce galaxy load
 author: ~master-morzod (@joemfb), ~norsyr-torryn (@yosoyubik)

--- a/UIPS/UIP-0113.md
+++ b/UIPS/UIP-0113.md
@@ -1,5 +1,5 @@
 ---
-uip: 0113
+uip: "0113"
 title: "%ames: Directed Messaging"
 description: a request/response discipline for the network.
 author: ~master-morzod

--- a/UIPS/UIP-0114.md
+++ b/UIPS/UIP-0114.md
@@ -1,5 +1,5 @@
 ---
-uip: 0114
+uip: "0114"
 title: OTA approval
 description: Kiln can optionally prompt users for approval before applying pending updates
 author: ~tinnus-napbus

--- a/UIPS/UIP-0115.md
+++ b/UIPS/UIP-0115.md
@@ -1,5 +1,5 @@
 ---
-uip: 0115
+uip: "0115"
 title: Breadth-First Arvo
 description: Breadth-First Move Processing in the Arvo Kernel
 author: ~wicdev-wisryt, ~rovnys-ricfer

--- a/UIPS/UIP-0116.md
+++ b/UIPS/UIP-0116.md
@@ -1,5 +1,5 @@
 ---
-uip: 0116
+uip: "0116"
 title: Arvo Ticks
 description: Pin Arvo's scry handler to a move tick
 author: ~wicdev-wisryt, ~rovnys-ricfer

--- a/UIPS/UIP-0117.md
+++ b/UIPS/UIP-0117.md
@@ -1,5 +1,5 @@
 ---
-uip: 0117
+uip: "0117"
 title: Ulam
 description: Self-Describing, Dynamically Typed Nouns
 author: ~rovnys-ricfer

--- a/UIPS/UIP-0118.md
+++ b/UIPS/UIP-0118.md
@@ -1,5 +1,5 @@
 ---
-uip: 0118
+uip: "0118"
 title: Encrypted Remote Scry 
 description: Enabling private data in the remote scry network
 author: ~hastuc-dibtux

--- a/UIPS/UIP-0119.md
+++ b/UIPS/UIP-0119.md
@@ -1,5 +1,5 @@
 ---
-uip: 0119
+uip: "0119"
 title: Pretty Printer Improvements
 description: Make the Hoon pretty printer robust and customizable
 author: ~sidnym-ladrut (@sidnym-ladrut)

--- a/UIPS/UIP-0120.md
+++ b/UIPS/UIP-0120.md
@@ -1,5 +1,5 @@
 ---
-uip: 0120
+uip: "0120"
 title: HTTP Streaming
 description: Support Media Streaming from Eyre
 author: ~rovnys-ricfer

--- a/UIPS/UIP-0121.md
+++ b/UIPS/UIP-0121.md
@@ -1,5 +1,5 @@
 ---
-uip: 0121
+uip: "0121"
 title: "%pine Request at Latest"
 description: Add a way to request the latest scry path
 author: ~rovnys-ricfer


### PR DESCRIPTION
Ran `sed -E -i 's/uip: ([0-9]+)/uip: "\1"/' UIPS/*.md`