### PR TITLE
uip-0135: update status and backcompat section

### DIFF
--- a/UIPS/UIP-0135.md
+++ b/UIPS/UIP-0135.md
@@ -23,7 +23,9 @@ and displaying `~2025.1.1` as `~2025.01.01`.
 
 ## Status
 
-[urbit/urbit#7257](https://github.com/urbit/urbit/pull/7257#pullrequestreview-3454487853)
+[urbit/urbit#7257](https://github.com/urbit/urbit/pull/7257),
+[urbit/urbit#7294](https://github.com/urbit/urbit/pull/7294)
+
 
 ## Motivation
 
@@ -93,11 +95,18 @@ transiently or working with their underlying integer values) should take
 particular care to either re-format their stored strings, or make sure the
 strings they ingest continue using the old format.
 
+When passing string representations of `@da` over the network, care must be
+taken to provide the recipient with a representation they know how to parse.
+A common place where this matters is encoding `@da`s in subscription paths.
+If there is no guarantee about the kelvin version of the recipient, it is
+recommended to continue sending the old representation.
+
 To help with the latter, we could consider introducing a `@dad` (**DA**te
 **D**eprecated) or similar which would retain the current `@da` rendering
 behavior without introducing any additional literal parsing syntax. Whether we
 would accept an aura for which there is rendering but no distinct parsing
-syntax is up for debate.
+syntax is up for debate. Alternatively, we could add a version of the atom
+rendering helpers that retains the old behavior.
 
 
 ## Reference Implementation


### PR DESCRIPTION
A common problem case for backwards compatibility was overlooked. We expand that section slightly to make mention of it.

Additionally, we link to a new related PR in the status section, and update the existing PR link to point to the whole PR rather than a specific review of it.